### PR TITLE
Adding auto-closing-tags + string constants (for <!DOCTYPE>)

### DIFF
--- a/src/crikey.cr
+++ b/src/crikey.cr
@@ -1,6 +1,8 @@
 require "./crikey/*"
 
 module Crikey
+	AUTO_CLOSING_TAGS = [:area, :base, :br, :col, :command, :embed, :hr, :img, :input, :keygen, :link, :menuitem, :meta, :param, :source, :track, :wbr]
+
   def self.array_to_html(data)
     return "" if data.empty?
     if data[1]? && data[1].is_a? NamedTuple
@@ -43,12 +45,18 @@ module Crikey
   def self.tag_without_attrs(data)
     String.build do |str|
       case data.first
-      when Symbol
-        str << "<" << data.first.to_s << ">"
-        data[1..-1].each {|t| str << Crikey.to_html(t) }
-        str << "</" << data.first.to_s << ">"
+			when Symbol
+				if Crikey::AUTO_CLOSING_TAGS.includes? data.first
+					str << "<" << data.first.to_s << " />"
+				else
+					str << "<" << data.first.to_s << ">"
+					data[1..-1].each {|t| str << Crikey.to_html(t) }
+					str << "</" << data.first.to_s << ">"
+				end
       when Array
-        data.each {|t| str << Crikey.to_html(t) }
+				data.each {|t| str << Crikey.to_html(t) }
+			when String
+				str << data.first
       end
     end
   end
@@ -56,13 +64,19 @@ module Crikey
   def self.tag_with_attrs(data)
     String.build do |str|
       case data.first
-      when Symbol
-        str << "<" << data.first.to_s << Crikey.to_html(data[1]) << ">"
-        data[2..-1].each {|t| str << Crikey.to_html(t) }
-        str << "</" << data.first.to_s << ">"
+			when Symbol
+				if Crikey::AUTO_CLOSING_TAGS.includes? data.first
+					str << "<" << data.first.to_s << Crikey.to_html(data[1]) << " />"
+				else
+					str << "<" << data.first.to_s << Crikey.to_html(data[1]) << ">"
+					data[2..-1].each {|t| str << Crikey.to_html(t) }
+					str << "</" << data.first.to_s << ">"
+				end
       when Array
-        data.each {|t| str << Crikey.to_html(t) }
-      end
+				data.each {|t| str << Crikey.to_html(t) }
+			when String
+				str << data.first
+			end
     end
   end
 


### PR DESCRIPTION
* If the first element of the array is a string, append the given string to the generated HTML and ignores given attributes/data. (useful to add the `<!DOCTYPE html>` at the beginning of the web page)
* Using "void-elements" like `<meta>` or `<link>` produces an auto-closing tag and ignores given data.

The purpose of this pull request is to allow (but not to enforce) generation of 100% compliant HTML 5 content (as tested with [the W3C validator](https://validator.w3.org)).